### PR TITLE
Added a module for starting the server from a Python script.

### DIFF
--- a/sirius/server.py
+++ b/sirius/server.py
@@ -1,0 +1,36 @@
+import os
+from threading import Timer
+import webbrowser
+
+
+def start_server():
+    """
+    Call this function to run the Django server from a Python script.
+    It will block the thread until the server is closed. It should
+    ran last in the pipeline.
+
+    EX:
+    from .server import start_server
+    start_server()
+    """
+    # Start the browser launch timer
+    t = Timer(3.0, delay_browser_launch)
+    t.start()
+
+    # Setup and run the Django server
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sirius_graph_tool.settings")
+
+    from django.core.management import call_command
+    from django.core.wsgi import get_wsgi_application
+
+    # Create the application
+    application = get_wsgi_application()
+
+    # Start the development server
+    # Turn off reloading when there are changes to the folder structure.
+    call_command('runserver',  '127.0.0.1:8000',  '--noreload')
+
+
+def delay_browser_launch():
+    webbrowser.open("http://127.0.0.1:8000")
+


### PR DESCRIPTION
This can be used at the end of the processing pipeline to start the server. There is also timer that launches a browser window after 3 seconds.

I did not incorporate it into __main__.py, because I thought Todd or Jane would be better suited to that task. 

Also, I have not used this approach before. Initial tests seemed promising. But, it may ending up being wasted effort. Just a warning.